### PR TITLE
Add native bag of words support for MLP

### DIFF
--- a/common/evaluators/bow_evaluator.py
+++ b/common/evaluators/bow_evaluator.py
@@ -1,0 +1,73 @@
+import warnings
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from sklearn import metrics
+from torch.utils.data import DataLoader, SequentialSampler, TensorDataset
+from tqdm import tqdm
+
+from datasets.bow_processors.abstract_processor import StreamingSparseDataset
+
+# Suppress warnings from sklearn.metrics
+warnings.filterwarnings('ignore')
+
+
+class BagOfWordsEvaluator(object):
+    def __init__(self, model, vectorizer, processor, args, split='dev'):
+        self.args = args
+        self.model = model
+        self.processor = processor
+        self.vectorizer = vectorizer
+
+        if split == 'test':
+            eval_examples = self.processor.get_test_examples(args.data_dir)
+        else:
+            eval_examples = self.processor.get_dev_examples(args.data_dir)
+
+        self.eval_features = vectorizer.transform([x.text for x in eval_examples])
+        self.eval_labels = [[float(x) for x in document.label] for document in eval_examples]
+
+    def get_scores(self, silent=False):
+        self.model.eval()
+        eval_data = StreamingSparseDataset(self.eval_features, self.eval_labels)
+        eval_dataloader = DataLoader(eval_data, shuffle=True, batch_size=self.args.batch_size)
+
+        total_loss = 0
+        nb_eval_steps = 0
+        target_labels = list()
+        predicted_labels = list()
+
+        for features, labels in tqdm(eval_dataloader, desc="Evaluating", disable=silent):
+            features = features.to(self.args.device)
+            labels = labels.to(self.args.device)
+
+            with torch.no_grad():
+                logits = self.model(features)
+
+            if self.args.n_gpu > 1:
+                logits = logits.view(labels.size())
+
+            if self.args.is_multilabel:
+                predicted_labels.extend(F.sigmoid(logits).round().long().cpu().detach().numpy())
+                target_labels.extend(labels.cpu().detach().numpy())
+                loss = F.binary_cross_entropy_with_logits(logits, labels.float(), size_average=False)
+            else:
+                predicted_labels.extend(torch.argmax(logits, dim=1).cpu().detach().numpy())
+                target_labels.extend(torch.argmax(labels, dim=1).cpu().detach().numpy())
+                loss = F.cross_entropy(logits, torch.argmax(labels, dim=1))
+
+            if self.args.n_gpu > 1:
+                loss = loss.mean()
+
+            total_loss += loss.item()
+            nb_eval_steps += 1
+
+        predicted_labels, target_labels = np.array(predicted_labels), np.array(target_labels)
+        accuracy = metrics.accuracy_score(target_labels, predicted_labels)
+        precision = metrics.precision_score(target_labels, predicted_labels, average='micro')
+        recall = metrics.recall_score(target_labels, predicted_labels, average='micro')
+        f1 = metrics.f1_score(target_labels, predicted_labels, average='micro')
+        avg_loss = total_loss / nb_eval_steps
+
+        return [accuracy, precision, recall, f1, avg_loss], ['accuracy', 'precision', 'recall', 'f1', 'avg_loss']

--- a/common/trainers/bow_trainer.py
+++ b/common/trainers/bow_trainer.py
@@ -1,0 +1,88 @@
+import datetime
+import os
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from tqdm import tqdm, trange
+
+from common.evaluators.bow_evaluator import BagOfWordsEvaluator
+from datasets.bow_processors.abstract_processor import StreamingSparseDataset
+
+
+class BagOfWordsTrainer(object):
+    def __init__(self, model, vectorizer, optimizer, processor, args):
+        self.args = args
+        self.model = model
+        self.processor = processor
+        self.optimizer = optimizer
+        self.vectorizer = vectorizer
+
+        train_examples = self.processor.get_train_examples(args.data_dir)
+        self.train_features = vectorizer.fit_transform([x.text for x in train_examples])
+        self.train_labels = [[float(x) for x in document.label] for document in train_examples]
+
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        self.snapshot_path = os.path.join(self.args.save_path, self.processor.NAME, '%s.pt' % timestamp)
+
+        self.log_header = 'Epoch Iteration Progress   Dev/Acc.  Dev/Pr.  Dev/Re.   Dev/F1   Dev/Loss'
+        self.log_template = ' '.join('{:>5.0f},{:>9.0f},{:>6.0f}/{:<5.0f} {:>6.4f},{:>8.4f},{:8.4f},{:8.4f},{:10.4f}'.split(','))
+
+        self.train_loss = 0
+        self.best_dev_f1 = 0
+        self.nb_train_steps = 0
+        self.unimproved_iters = 0
+        self.early_stop = False
+
+    def train_epoch(self, train_dataloader):
+        for step, batch in enumerate(tqdm(train_dataloader, desc="Training")):
+            self.model.train()
+            self.optimizer.zero_grad()
+
+            features, labels = tuple(t.to(self.args.device) for t in batch)
+            logits = self.model(features)
+
+            if self.args.n_gpu > 1:
+                logits = logits.view(labels.size())
+
+            if self.args.is_multilabel:
+                loss = F.binary_cross_entropy_with_logits(logits, labels.float())
+            else:
+                loss = F.cross_entropy(logits, torch.argmax(labels, dim=1))
+
+            if self.args.n_gpu > 1:
+                loss = loss.mean()
+
+            loss.backward()
+            self.optimizer.step()
+            self.train_loss += loss.item()
+            self.nb_train_steps += 1
+
+    def train(self):
+        train_data = StreamingSparseDataset(self.train_features, self.train_labels)
+        train_dataloader = DataLoader(train_data, shuffle=True, batch_size=self.args.batch_size)
+
+        print("Number of examples: ", len(self.train_labels))
+        print("Batch size:", self.args.batch_size)
+
+        for epoch in trange(int(self.args.epochs), desc="Epoch"):
+            self.train_epoch(train_dataloader)
+            dev_evaluator = BagOfWordsEvaluator(self.model, self.vectorizer, self.processor, self.args, split='dev')
+            dev_acc, dev_precision, dev_recall, dev_f1, dev_loss = dev_evaluator.get_scores()[0]
+
+            # Print validation results
+            tqdm.write(self.log_header)
+            tqdm.write(self.log_template.format(epoch + 1, self.nb_train_steps, epoch + 1, self.args.epochs,
+                                                dev_acc, dev_precision, dev_recall, dev_f1, dev_loss))
+
+            # Update validation results
+            if dev_f1 > self.best_dev_f1:
+                self.unimproved_iters = 0
+                self.best_dev_f1 = dev_f1
+                torch.save(self.model, self.snapshot_path)
+            else:
+                self.unimproved_iters += 1
+                if self.unimproved_iters >= self.args.patience:
+                    self.early_stop = True
+                    tqdm.write("Early Stopping. Epoch: {}, Best Dev F1: {}".format(epoch, self.best_dev_f1))
+                    break

--- a/datasets/bow_processors/aapd_processor.py
+++ b/datasets/bow_processors/aapd_processor.py
@@ -1,0 +1,29 @@
+import os
+
+from datasets.bow_processors.abstract_processor import BagOfWordsProcessor, InputExample
+
+
+class AAPDProcessor(BagOfWordsProcessor):
+    NAME = 'AAPD'
+    NUM_CLASSES = 54
+    VOCAB_SIZE = 66192
+    IS_MULTILABEL = True
+
+    def get_train_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir,'AAPD', 'train.tsv')), 'train')
+
+    def get_dev_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'AAPD', 'dev.tsv')), 'dev')
+
+    def get_test_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'AAPD', 'test.tsv')), 'test')
+
+    def _create_examples(self, lines, set_type):
+        examples = []
+        for (i, line) in enumerate(lines):
+            guid = '%s-%s' % (set_type, i)
+            examples.append(InputExample(guid=guid, text=line[1], label=line[0]))
+        return examples

--- a/datasets/bow_processors/abstract_processor.py
+++ b/datasets/bow_processors/abstract_processor.py
@@ -1,0 +1,70 @@
+import csv
+import sys
+
+import torch
+from torch import tensor
+from torch.utils.data import Dataset
+
+
+class InputExample(object):
+    def __init__(self, guid, text, label=None):
+        self.guid = guid
+        self.text = text
+        self.label = label
+
+
+class BagOfWordsProcessor(object):
+    def get_train_examples(self, data_dir):
+        """
+        Gets a collection of InputExamples for the train set
+        :param data_dir:
+        :return:
+        """
+        raise NotImplementedError()
+
+    def get_dev_examples(self, data_dir):
+        """
+        Gets a collection of InputExamples for the dev set
+        :param data_dir:
+        :return:
+        """
+        raise NotImplementedError()
+
+    def get_test_examples(self, data_dir):
+        """
+        Gets a collection of InputExamples for the test set
+        :param data_dir:
+        :return:
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def _read_tsv(cls, input_file, quotechar=None):
+        """
+        Reads a Tab Separated Values (TSV) file
+        :param input_file:
+        :param quotechar:
+        :return:
+        """
+        with open(input_file, "r") as f:
+            reader = csv.reader(f, delimiter="\t", quotechar=quotechar)
+            lines = []
+            for line in reader:
+                if sys.version_info[0] == 2:
+                    line = list(str(cell, 'utf-8') for cell in line)
+                lines.append(line)
+            return lines
+
+
+class StreamingSparseDataset(Dataset):
+    def __init__(self, features, labels):
+        self.features = features
+        self.labels = labels
+
+    def __getitem__(self, idx):
+        feature_tensor = tensor(self.features.getrow(idx).toarray(), dtype=torch.float)
+        label_tensor = tensor(self.labels[idx], dtype=torch.long)
+        return feature_tensor, label_tensor
+
+    def __len__(self):
+        return len(self.labels)

--- a/datasets/bow_processors/imdb_processor.py
+++ b/datasets/bow_processors/imdb_processor.py
@@ -1,0 +1,29 @@
+import os
+
+from datasets.bow_processors.abstract_processor import BagOfWordsProcessor, InputExample
+
+
+class IMDBProcessor(BagOfWordsProcessor):
+    NAME = 'IMDB'
+    NUM_CLASSES = 10
+    VOCAB_SIZE = 395495
+    IS_MULTILABEL = False
+
+    def get_train_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'IMDB', 'train.tsv')), 'train')
+
+    def get_dev_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'IMDB', 'dev.tsv')), 'dev')
+
+    def get_test_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'IMDB', 'test.tsv')), 'test')
+
+    def _create_examples(self, lines, set_type):
+        examples = []
+        for (i, line) in enumerate(lines):
+            guid = '%s-%s' % (set_type, i)
+            examples.append(InputExample(guid=guid, text=line[1], label=line[0]))
+        return examples

--- a/datasets/bow_processors/reuters_processor.py
+++ b/datasets/bow_processors/reuters_processor.py
@@ -1,0 +1,29 @@
+import os
+
+from datasets.bow_processors.abstract_processor import BagOfWordsProcessor, InputExample
+
+
+class ReutersProcessor(BagOfWordsProcessor):
+    NAME = 'Reuters'
+    NUM_CLASSES = 90
+    VOCAB_SIZE = 36308
+    IS_MULTILABEL = True
+
+    def get_train_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'Reuters', 'train.tsv')), 'train')
+
+    def get_dev_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'Reuters', 'dev.tsv')), 'dev')
+
+    def get_test_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'Reuters', 'test.tsv')), 'test')
+
+    def _create_examples(self, lines, set_type):
+        examples = []
+        for (i, line) in enumerate(lines):
+            guid = '%s-%s' % (set_type, i)
+            examples.append(InputExample(guid=guid, text=line[1], label=line[0]))
+        return examples

--- a/datasets/bow_processors/yelp2014_processor.py
+++ b/datasets/bow_processors/yelp2014_processor.py
@@ -1,0 +1,29 @@
+import os
+
+from datasets.bow_processors.abstract_processor import BagOfWordsProcessor, InputExample
+
+
+class Yelp2014Processor(BagOfWordsProcessor):
+    NAME = 'Yelp2014'
+    NUM_CLASSES = 5
+    VOCAB_SIZE = 490166
+    IS_MULTILABEL = False
+
+    def get_train_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'Yelp2014', 'train.tsv')), 'train')
+
+    def get_dev_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'Yelp2014', 'dev.tsv')), 'dev')
+
+    def get_test_examples(self, data_dir):
+        return self._create_examples(
+            self._read_tsv(os.path.join(data_dir, 'Yelp2014', 'test.tsv')), 'test')
+
+    def _create_examples(self, lines, set_type):
+        examples = []
+        for (i, line) in enumerate(lines):
+            guid = '%s-%s' % (set_type, i)
+            examples.append(InputExample(guid=guid, text=line[1], label=line[0]))
+        return examples

--- a/datasets/reuters.py
+++ b/datasets/reuters.py
@@ -121,33 +121,3 @@ class ReutersCharQuantized(Reuters):
         """
         train, val, test = cls.splits(path)
         return BucketIterator.splits((train, val, test), batch_size=batch_size, repeat=False, shuffle=shuffle, device=device)
-
-
-class ReutersTFIDF(Reuters):
-    VOCAB_SIZE = 30485
-    TEXT_FIELD = Field(sequential=False, use_vocab=False, batch_first=True, preprocessing=load_json, dtype=torch.float)
-
-    @classmethod
-    def splits(cls, path, train=os.path.join('Reuters', 'tfidf_train.tsv'),
-               validation=os.path.join('Reuters', 'tfidf_dev.tsv'),
-               test=os.path.join('Reuters', 'tfidf_test.tsv'), **kwargs):
-        return super(Reuters, cls).splits(
-            path, train=train, validation=validation, test=test,
-            format='tsv', fields=[('label', cls.LABEL_FIELD), ('text', cls.TEXT_FIELD)]
-        )
-
-    @classmethod
-    def iters(cls, path, vectors_name, vectors_cache, batch_size=64, shuffle=True, device=0, vectors=None,
-              unk_init=torch.Tensor.zero_):
-        """
-        :param path: directory containing train, test, dev files
-        :param vectors_name: name of word vectors file
-        :param vectors_cache: path to directory containing word vectors file
-        :param batch_size: batch size
-        :param device: GPU device
-        :param vectors: custom vectors - either predefined torchtext vectors or your own custom Vector classes
-        :param unk_init: function used to generate vector for OOV words
-        :return:
-        """
-        train, val, test = cls.splits(path)
-        return BucketIterator.splits((train, val, test), batch_size=batch_size, repeat=False, shuffle=shuffle, device=device)

--- a/models/mlp/__main__.py
+++ b/models/mlp/__main__.py
@@ -1,141 +1,93 @@
 import os
 import random
-from copy import deepcopy
 
 import numpy as np
 import torch.onnx
+from nltk import word_tokenize
+from nltk.corpus import stopwords
+from sklearn.feature_extraction.text import TfidfVectorizer
 
-from common.evaluate import EvaluatorFactory
-from common.train import TrainerFactory
-from datasets.aapd import AAPD
-from datasets.imdb import IMDB
-from datasets.reuters import ReutersTFIDF
-from datasets.yelp2014 import Yelp2014
+from common.evaluators.bow_evaluator import BagOfWordsEvaluator
+from common.trainers.bow_trainer import BagOfWordsTrainer
+from datasets.bow_processors.aapd_processor import AAPDProcessor
+from datasets.bow_processors.imdb_processor import IMDBProcessor
+from datasets.bow_processors.reuters_processor import ReutersProcessor
+from datasets.bow_processors.yelp2014_processor import Yelp2014Processor
 from models.mlp.args import get_args
 from models.mlp.model import MLP
 
+# String templates for logging results
 
-def evaluate_dataset(split_name, dataset_cls, model, embedding, loader, batch_size, device, is_multilabel):
-    saved_model_evaluator = EvaluatorFactory.get_evaluator(dataset_cls, model, embedding, loader, batch_size, device)
-    if hasattr(saved_model_evaluator, 'is_multilabel'):
-        saved_model_evaluator.is_multilabel = is_multilabel
-    if hasattr(saved_model_evaluator, 'ignore_lengths'):
-        saved_model_evaluator.ignore_lengths = True
+LOG_HEADER = 'Split  Dev/Acc.  Dev/Pr.  Dev/Re.   Dev/F1   Dev/Loss'
+LOG_TEMPLATE = ' '.join('{:>5s},{:>9.4f},{:>8.4f},{:8.4f},{:8.4f},{:10.4f}'.split(','))
 
-    scores, metric_names = saved_model_evaluator.get_scores()
-    print('Evaluation metrics for', split_name)
-    print(metric_names)
-    print(scores)
+
+def evaluate_split(model, vectorizer, processor, args, split='dev'):
+    evaluator = BagOfWordsEvaluator(model, vectorizer, processor, args, split)
+    accuracy, precision, recall, f1, avg_loss = evaluator.get_scores(silent=True)[0]
+    print('\n' + LOG_HEADER)
+    print(LOG_TEMPLATE.format(split.upper(), accuracy, precision, recall, f1, avg_loss))
 
 
 if __name__ == '__main__':
     # Set default configuration in args.py
     args = get_args()
+    n_gpu = torch.cuda.device_count()
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+
+    print('Number of GPUs:', n_gpu)
+    print('Device:', str(device).upper())
 
     # Set random seed for reproducibility
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
-    torch.backends.cudnn.deterministic = True
-
-    if not args.cuda:
-        args.gpu = -1
-
-    if torch.cuda.is_available() and args.cuda:
-        print('Note: You are using GPU for training')
-        torch.cuda.set_device(args.gpu)
-        torch.cuda.manual_seed(args.seed)
-        args.gpu = torch.device('cuda:%d' % args.gpu)
-
-    if torch.cuda.is_available() and not args.cuda:
-        print('Warning: Using CPU for training')
+    if n_gpu > 0:
+        torch.cuda.manual_seed_all(args.seed)
 
     dataset_map = {
-        'Reuters': ReutersTFIDF,
-        'AAPD': AAPD,
-        'IMDB': IMDB,
-        'Yelp2014': Yelp2014
+        'Reuters': ReutersProcessor,
+        'AAPD': AAPDProcessor,
+        'IMDB': IMDBProcessor,
+        'Yelp2014': Yelp2014Processor
     }
 
     if args.dataset not in dataset_map:
         raise ValueError('Unrecognized dataset')
-    else:
-        dataset_class = dataset_map[args.dataset]
-        train_iter, dev_iter, test_iter = dataset_map[args.dataset].iters(args.data_dir, None, None,
-                                                                          batch_size=args.batch_size,
-                                                                          device=args.gpu,
-                                                                          unk_init=None)
 
-    config = deepcopy(args)
-    config.dataset = train_iter.dataset
-    config.target_class = train_iter.dataset.NUM_CLASSES
-    config.words_num = train_iter.dataset.VOCAB_SIZE
+    args.device = device
+    args.n_gpu = n_gpu
+    args.num_labels = dataset_map[args.dataset].NUM_CLASSES
+    args.is_multilabel = dataset_map[args.dataset].IS_MULTILABEL
+    args.vocab_size = min(args.max_vocab_size, dataset_map[args.dataset].VOCAB_SIZE)
 
-    print('Dataset:', args.dataset)
-    print('No. of target classes:', train_iter.dataset.NUM_CLASSES)
-    print('No. of train instances', len(train_iter.dataset))
-    print('No. of dev instances', len(dev_iter.dataset))
-    print('No. of test instances', len(test_iter.dataset))
-
-    if args.resume_snapshot:
-        if args.cuda:
-            model = torch.load(args.resume_snapshot, map_location=lambda storage, location: storage.cuda(args.gpu))
-        else:
-            model = torch.load(args.resume_snapshot, map_location=lambda storage, location: storage)
-    else:
-        model = MLP(config)
-        if args.cuda:
-            model.cuda()
+    train_examples = None
+    processor = dataset_map[args.dataset]()
+    vectorizer = TfidfVectorizer(stop_words=stopwords.words("english"),
+                                 # max_features=args.max_vocab_size,
+                                 tokenizer=word_tokenize)
 
     if not args.trained_model:
+        train_examples = processor.get_train_examples(args.data_dir)
         save_path = os.path.join(args.save_path, dataset_map[args.dataset].NAME)
         os.makedirs(save_path, exist_ok=True)
 
+    model = MLP(args)
+    model.to(device)
+
+    if n_gpu > 1:
+        model = torch.nn.DataParallel(model)
+
     parameter = filter(lambda p: p.requires_grad, model.parameters())
     optimizer = torch.optim.Adam(parameter, lr=args.lr, weight_decay=args.weight_decay)
-
-    train_evaluator = EvaluatorFactory.get_evaluator(dataset_map[args.dataset], model, None, train_iter, args.batch_size, args.gpu)
-    test_evaluator = EvaluatorFactory.get_evaluator(dataset_map[args.dataset], model, None, test_iter, args.batch_size, args.gpu)
-    dev_evaluator = EvaluatorFactory.get_evaluator(dataset_map[args.dataset], model, None, dev_iter, args.batch_size, args.gpu)
-
-    if hasattr(train_evaluator, 'is_multilabel'):
-        train_evaluator.is_multilabel = dataset_class.IS_MULTILABEL
-    if hasattr(test_evaluator, 'is_multilabel'):
-        test_evaluator.is_multilabel = dataset_class.IS_MULTILABEL
-    if hasattr(dev_evaluator, 'is_multilabel'):
-        dev_evaluator.is_multilabel = dataset_class.IS_MULTILABEL
-    if hasattr(dev_evaluator, 'ignore_lengths'):
-        dev_evaluator.ignore_lengths = True
-    if hasattr(test_evaluator, 'ignore_lengths'):
-        test_evaluator.ignore_lengths = True
-
-    trainer_config = {
-        'optimizer': optimizer,
-        'batch_size': args.batch_size,
-        'log_interval': args.log_every,
-        'patience': args.patience,
-        'model_outfile': args.save_path,
-        'is_multilabel': dataset_class.IS_MULTILABEL,
-        'ignore_lengths': True
-    }
-
-    trainer = TrainerFactory.get_trainer(args.dataset, model, None, train_iter, trainer_config, train_evaluator, test_evaluator, dev_evaluator)
+    trainer = BagOfWordsTrainer(model, vectorizer, optimizer, processor, args)
 
     if not args.trained_model:
-        trainer.train(args.epochs)
-    else:
-        if args.cuda:
-            model = torch.load(args.trained_model, map_location=lambda storage, location: storage.cuda(args.gpu))
-        else:
-            model = torch.load(args.trained_model, map_location=lambda storage, location: storage)
-
-    # Calculate dev and test metrics
-    if hasattr(trainer, 'snapshot_path'):
+        trainer.train()
         model = torch.load(trainer.snapshot_path)
+    else:
+        model = torch.load(args.trained_model, map_location=lambda storage, location: storage)
+        model = model.to(device)
 
-    evaluate_dataset('dev', dataset_map[args.dataset], model, None, dev_iter, args.batch_size,
-                     is_multilabel=dataset_class.IS_MULTILABEL,
-                     device=args.gpu)
-    evaluate_dataset('test', dataset_map[args.dataset], model, None, test_iter, args.batch_size,
-                     is_multilabel=dataset_class.IS_MULTILABEL,
-                     device=args.gpu)
+    evaluate_split(model, vectorizer, processor, args, split='dev')
+    evaluate_split(model, vectorizer, processor, args, split='test')

--- a/models/mlp/args.py
+++ b/models/mlp/args.py
@@ -7,7 +7,7 @@ def get_args():
     parser = models.args.get_args()
 
     parser.add_argument('--dataset', type=str, default='Reuters', choices=['Reuters', 'AAPD', 'IMDB', 'Yelp2014'])
-    parser.add_argument('--embed-dim', type=int, default=300)
+    parser.add_argument('--max-vocab-size', type=int, default=500000)
     parser.add_argument('--dropout', type=float, default=0)
     parser.add_argument('--epoch-decay', type=int, default=15)
     parser.add_argument('--weight-decay', type=float, default=0)

--- a/models/mlp/model.py
+++ b/models/mlp/model.py
@@ -6,10 +6,8 @@ class MLP(nn.Module):
 
     def __init__(self, config):
         super().__init__()
-        dataset = config.dataset
-        target_class = config.target_class
         self.dropout = nn.Dropout(config.dropout)
-        self.fc1 = nn.Linear(dataset.VOCAB_SIZE, target_class)
+        self.fc1 = nn.Linear(config.vocab_size, config.num_labels)
 
     def forward(self, x, **kwargs):
         x = torch.squeeze(x)  # (batch, vocab_size)


### PR DESCRIPTION
The usage of TorchText for learning from bag of words representations was a bottleneck in Hedwig. TorchText is optimized for dealing with plain text and word embeddings, not tf-idf values. It doesn't support compressed input files (and hence we have to store tf-idf values as plain text, leading to files larger than 100 GB), and doesn't seem to be efficient with memory for this case.

This pull request introduces a new trainer, evaluator and data loader classes specifically for dealing with tf-idf representations as sparse matrices. This would allow us to have much larger vocabulary sizes across larger datasets such as IMDB and Yelp.