### PR TITLE
[WIP] DocBERT Colab notebook

### DIFF
--- a/datasets/bow_processors/reuters_processor.py
+++ b/datasets/bow_processors/reuters_processor.py
@@ -6,7 +6,7 @@ from datasets.bow_processors.abstract_processor import BagOfWordsProcessor, Inpu
 class ReutersProcessor(BagOfWordsProcessor):
     NAME = 'Reuters'
     NUM_CLASSES = 90
-    VOCAB_SIZE = 36308
+    VOCAB_SIZE = 36311
     IS_MULTILABEL = True
 
     def get_train_examples(self, data_dir):

--- a/models/bert/__main__.py
+++ b/models/bert/__main__.py
@@ -71,8 +71,9 @@ if __name__ == '__main__':
 
     args.is_hierarchical = False
     processor = dataset_map[args.dataset]()
-    pretrained_vocab_path = PRETRAINED_VOCAB_ARCHIVE_MAP[args.model]
-    tokenizer = BertTokenizer.from_pretrained(pretrained_vocab_path)
+    if not args.hf_checkpoint:
+        pretrained_vocab_path = PRETRAINED_VOCAB_ARCHIVE_MAP[args.model]
+    tokenizer = BertTokenizer.from_pretrained(args.model)
 
     train_examples = None
     num_train_optimization_steps = None
@@ -81,7 +82,7 @@ if __name__ == '__main__':
         num_train_optimization_steps = int(
             len(train_examples) / args.batch_size / args.gradient_accumulation_steps) * args.epochs
 
-    pretrained_model_path = args.model if os.path.isfile(args.model) else PRETRAINED_MODEL_ARCHIVE_MAP[args.model]
+    pretrained_model_path = args.model if os.path.isfile(args.model) or args.hf_checkpoint else PRETRAINED_MODEL_ARCHIVE_MAP[args.model]
     model = BertForSequenceClassification.from_pretrained(pretrained_model_path, num_labels=args.num_labels)
 
     if args.fp16:

--- a/models/bert/__main__.py
+++ b/models/bert/__main__.py
@@ -71,9 +71,8 @@ if __name__ == '__main__':
 
     args.is_hierarchical = False
     processor = dataset_map[args.dataset]()
-    if not args.hf_checkpoint:
-        pretrained_vocab_path = PRETRAINED_VOCAB_ARCHIVE_MAP[args.model]
-    tokenizer = BertTokenizer.from_pretrained(args.model)
+    pretrained_vocab_path = PRETRAINED_VOCAB_ARCHIVE_MAP[args.model]
+    tokenizer = BertTokenizer.from_pretrained(pretrained_vocab_path)
 
     train_examples = None
     num_train_optimization_steps = None
@@ -82,7 +81,7 @@ if __name__ == '__main__':
         num_train_optimization_steps = int(
             len(train_examples) / args.batch_size / args.gradient_accumulation_steps) * args.epochs
 
-    pretrained_model_path = args.model if os.path.isfile(args.model) or args.hf_checkpoint else PRETRAINED_MODEL_ARCHIVE_MAP[args.model]
+    pretrained_model_path = args.model if os.path.isfile(args.model) else PRETRAINED_MODEL_ARCHIVE_MAP[args.model]
     model = BertForSequenceClassification.from_pretrained(pretrained_model_path, num_labels=args.num_labels)
 
     if args.fp16:
@@ -138,4 +137,3 @@ if __name__ == '__main__':
 
     evaluate_split(model, processor, tokenizer, args, split='dev')
     evaluate_split(model, processor, tokenizer, args, split='test')
-

--- a/models/bert/args.py
+++ b/models/bert/args.py
@@ -7,7 +7,6 @@ def get_args():
     parser = models.args.get_args()
 
     parser.add_argument('--model', default=None, type=str, required=True)
-    parser.add_argument('--hf-checkpoint', default=False, type=bool)
     parser.add_argument('--dataset', type=str, default='SST-2', choices=['SST-2', 'AGNews', 'Reuters', 'AAPD', 'IMDB', 'Yelp2014'])
     parser.add_argument('--save-path', type=str, default=os.path.join('model_checkpoints', 'bert'))
     parser.add_argument('--cache-dir', default='cache', type=str)

--- a/models/bert/args.py
+++ b/models/bert/args.py
@@ -7,6 +7,7 @@ def get_args():
     parser = models.args.get_args()
 
     parser.add_argument('--model', default=None, type=str, required=True)
+    parser.add_argument('--hf-checkpoint', default=False, type=bool)
     parser.add_argument('--dataset', type=str, default='SST-2', choices=['SST-2', 'AGNews', 'Reuters', 'AAPD', 'IMDB', 'Yelp2014'])
     parser.add_argument('--save-path', type=str, default=os.path.join('model_checkpoints', 'bert'))
     parser.add_argument('--cache-dir', default='cache', type=str)

--- a/models/lr/__main__.py
+++ b/models/lr/__main__.py
@@ -58,7 +58,6 @@ if __name__ == '__main__':
     args.n_gpu = n_gpu
     args.num_labels = dataset_map[args.dataset].NUM_CLASSES
     args.is_multilabel = dataset_map[args.dataset].IS_MULTILABEL
-    args.vocab_size = min(args.max_vocab_size, dataset_map[args.dataset].VOCAB_SIZE)
 
     train_examples = None
     processor = dataset_map[args.dataset]()
@@ -70,6 +69,12 @@ if __name__ == '__main__':
         train_examples = processor.get_train_examples(args.data_dir)
         save_path = os.path.join(args.save_path, dataset_map[args.dataset].NAME)
         os.makedirs(save_path, exist_ok=True)
+
+    if train_examples:
+        train_features = vectorizer.fit_transform([x.text for x in train_examples])
+        dataset_map[args.dataset].VOCAB_SIZE = train_features.shape[1]
+    
+    args.vocab_size = min(args.max_vocab_size, dataset_map[args.dataset].VOCAB_SIZE)
 
     model = LogisticRegression(args)
     model.to(device)


### PR DESCRIPTION
I was working on implementing a [Colab notebook](https://colab.research.google.com/drive/1LO0MWpO4QEbxLMdX7F03hF818ray6XHj#scrollTo=sSOGd-ESnOJz) to replicate some of the results in the docBERT paper. Notebook still need to be polished and i'll add it in a future commit.

One of the issues when running the LogisticRegression was the default vocab size of 36308 which results in mismatch in LogisticRegression when using BagOfWordsTrainer. Updating the vocab size to 36311 solves the issue.

```
Full traceback:
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/content/hedwig/models/lr/__main__.py", line 85, in <module>
    trainer.train()
  File "/content/hedwig/common/trainers/bow_trainer.py", line 69, in train
    self.train_epoch(train_dataloader)
  File "/content/hedwig/common/trainers/bow_trainer.py", line 43, in train_epoch
    logits = self.model(features)
  File "/usr/local/lib/python3.6/dist-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/content/hedwig/models/lr/model.py", line 15, in forward
    logit = self.fc1(x)  # (batch, target_size)
  File "/usr/local/lib/python3.6/dist-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/torch/nn/modules/linear.py", line 87, in forward
    return F.linear(input, self.weight, self.bias)
  File "/usr/local/lib/python3.6/dist-packages/torch/nn/functional.py", line 1610, in linear
    ret = torch.addmm(bias, input, weight.t())
RuntimeError: size mismatch, m1: [32 x 36311], m2: [36308 x 90] at /pytorch/aten/src/THC/generic/THCTensorMathBlas.cu:283
```

It would also be helpful to have a command line argument for loading the pertained BERT model provided by Hugging Face instead of having to have locally saved weights.

**Notebook specific**:
It’s difficult to evaluate the rest of the models like BERT large and simple LSTM with word2vec because colab runs out of ram (16GB).

For the pretrained BERT models I used the [uncased weights provided by HF](https://huggingface.co/transformers/pretrained_models.html). However in 2 trails of base BERT on Reuters the test F1 score is 87.9 and 87.7 slightly different to 90.7 reported in the paper.

```
Split  Dev/Acc.  Dev/Pr.  Dev/Re.   Dev/F1   Dev/Loss
 TEST    0.8323   0.9264   0.8370   0.8794    15.9778
```

```
Split  Dev/Acc.  Dev/Pr.  Dev/Re.   Dev/F1   Dev/Loss
 TEST    0.8297   0.9284   0.8317   0.8774    16.5026

```
In terms of content for replicating the results, would LR, BERT base on Reuters x 2, and BERT base IMDB be a good start? What other results would it be good to train and include?


