### PR TITLE
Update instructions for setting up hedwig-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ After cloning the hedwig-data repo, you need to unzip the embeddings and run the
 
 ```bash
 cd hedwig-data/embeddings/word2vec 
-gzip -d GoogleNews-vectors-negative300.bin.gz 
-python bin2txt.py GoogleNews-vectors-negative300.bin GoogleNews-vectors-negative300.txt 
+tar -xvzf GoogleNews-vectors-negative300.tgz
 ```
 
 **If you are an internal Hedwig contributor using the machines in the lab, follow the instructions [here](docs/internal-instructions.md).**


### PR DESCRIPTION
I was trying to get hedwig running and then realized that I need gensim to run `bin2txt.py`, a dependency that's not included in `requirements.txt` as hedwig itself doesn't use gensim. I've updated hedwig-data to remove this additional step to make it easier to replicate our results.

Addresses: Issue https://github.com/castorini/hedwig/issues/61
Related to: https://git.uwaterloo.ca/jimmylin/hedwig-data/-/commit/c6544d1efbcf99c6f466658d981b737b0d3c0034
