### PR TITLE
update char_cnn and fasttext

### DIFF
--- a/models/char_cnn/README.md
+++ b/models/char_cnn/README.md
@@ -10,7 +10,7 @@ To run the model on Reuters dataset, just run the following from the Castor work
 python -m models.char_cnn --dataset Reuters --batch-size 32 --lr 0.01 --seed 3435
 ```
 
-in order to run the indetical implementation of the paper, run the following from the Castor working directory:
+in order to run the implementation of the paper, run the following from the Castor working directory:
 
 ```
 python -m models.char_cnn --dataset Reuters --batch-size 32 --lr 0.01 --seed 3435 --using_fixed True
@@ -27,14 +27,9 @@ To test the model, you can use the following command.
 ```
 python -m models.char_cnn --dataset Reuters --batch_size 32 --trained-model models/char_cnn/saves/Reuters/best_model.pt --seed 3435
 ```
-## Dataset
 
-We experiment the model on the following datasets.
 
-- Reuters (ModApte)
-- AAPD
-
-**It should be noted** that if version that follows the implementation of the [Char-CNN (2015)](http://papers.nips.cc/paper/5782-character-level-convolutional-networks-for-text-classification.pdf) produces an dev F1 of 0 on Reuters unless you run the model with the following (strict) parameters:
+**It should be noted** that the version that follows the implementation of the [Char-CNN (2015)](http://papers.nips.cc/paper/5782-character-level-convolutional-networks-for-text-classification.pdf) needs to be run with the following (or similar) parameters otherwise it produces an dev F1 of 0 on Reuters:
 ```
 python3 -m models.char_cnn --dataset Reuters --batch-size 1 --lr 0.1 --seed 3435 --using_fixed True --epochs 30 --patience 30
 ```

--- a/models/char_cnn/README.md
+++ b/models/char_cnn/README.md
@@ -7,7 +7,13 @@ Implementation of [Char-CNN (2015)](http://papers.nips.cc/paper/5782-character-l
 To run the model on Reuters dataset, just run the following from the Castor working directory:
 
 ```
-python -m models.char_cnn --dataset Reuters --batch-size 128 --lr 0.001 --seed 3435
+python -m models.char_cnn --dataset Reuters --batch-size 32 --lr 0.01 --seed 3435
+```
+
+in order to run the indetical implementation of the paper, run the following from the Castor working directory:
+
+```
+python -m models.char_cnn --dataset Reuters --batch-size 32 --lr 0.01 --seed 3435 --using_fixed True
 ```
 
 The best model weights will be saved in
@@ -28,7 +34,11 @@ We experiment the model on the following datasets.
 - Reuters (ModApte)
 - AAPD
 
-**It should be noted** that if version that follows the implementation of the [Char-CNN (2015)](http://papers.nips.cc/paper/5782-character-level-convolutional-networks-for-text-classification.pdf) produces an dev F1 of 0 on Reuters
+**It should be noted** that if version that follows the implementation of the [Char-CNN (2015)](http://papers.nips.cc/paper/5782-character-level-convolutional-networks-for-text-classification.pdf) produces an dev F1 of 0 on Reuters unless you run the model with the following (strict) parameters:
+```
+python3 -m models.char_cnn --dataset Reuters --batch-size 1 --lr 0.1 --seed 3435 --using_fixed True --epochs 30 --patience 30
+```
+
 ## Settings
 
 Adam is used for training.

--- a/models/char_cnn/README.md
+++ b/models/char_cnn/README.md
@@ -28,6 +28,7 @@ We experiment the model on the following datasets.
 - Reuters (ModApte)
 - AAPD
 
+**It should be noted** that if version that follows the implementation of the [Char-CNN (2015)](http://papers.nips.cc/paper/5782-character-level-convolutional-networks-for-text-classification.pdf) produces an dev F1 of 0 on Reuters
 ## Settings
 
 Adam is used for training.

--- a/models/char_cnn/args.py
+++ b/models/char_cnn/args.py
@@ -14,6 +14,14 @@ def get_args():
     parser.add_argument('--epoch-decay', type=int, default=15)
     parser.add_argument('--weight-decay', type=float, default=0)
 
+    parser.add_argument('--number_of_characters', type=float, default=68)
+    parser.add_argument('--first_kernel', type=int, default=7)
+    parser.add_argument('--second_kernel', type=int, default=3)
+    parser.add_argument('--pool_size', type=int, default=3)
+    parser.add_argument('--max_sentence_length', type=int, default=1000)
+
+
+
     parser.add_argument('--word-vectors-dir', default=os.path.join(os.pardir, 'hedwig-data', 'embeddings', 'word2vec'))
     parser.add_argument('--word-vectors-file', default='GoogleNews-vectors-negative300.txt')
     parser.add_argument('--save-path', type=str, default=os.path.join('model_checkpoints', 'char_cnn'))

--- a/models/char_cnn/args.py
+++ b/models/char_cnn/args.py
@@ -20,6 +20,8 @@ def get_args():
     parser.add_argument('--pool_size', type=int, default=3)
     parser.add_argument('--max_sentence_length', type=int, default=1000)
 
+    parser.add_argument('--using_fixed', type=bool, default=False)
+
 
 
     parser.add_argument('--word-vectors-dir', default=os.path.join(os.pardir, 'hedwig-data', 'embeddings', 'word2vec'))

--- a/models/char_cnn/model.py
+++ b/models/char_cnn/model.py
@@ -11,16 +11,16 @@ class CharCNN(nn.Module):
         self.is_cuda_enabled = config.cuda
 
         num_conv_filters = config.num_conv_filters
-        output_channel = config.output_channel
+        output_channel = config.output_channel #this parameter is not used anymore for conv6
         num_affine_neurons = config.num_affine_neurons
         target_class = config.target_class
-        #added paremeters in the config
-        input_channel = config.number_of_characters #number of characters
+        # added paremeters in the config
+        input_channel = config.number_of_characters  # number of characters
         first_kernel_size = config.first_kernel
         second_kernel_size = config.second_kernel
         pool_size = config.pool_size
-        # we can add these parameters in the config
-        max_sentence_length = config.max_sentence_length #maximum number of characters per sentence
+
+        max_sentence_length = config.max_sentence_length  # maximum number of characters per sentence
 
         self.conv1 = nn.Conv1d(input_channel, num_conv_filters, kernel_size=first_kernel_size)
         self.conv2 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=first_kernel_size)
@@ -33,6 +33,7 @@ class CharCNN(nn.Module):
         temp = first_kernel_size - 1 + pool_size * (first_kernel_size - 1) + (
                 pool_size ** 2 * 4 * (second_kernel_size - 1))
         linear_size_temp = int((max_sentence_length - temp) / (pool_size ** 3)) * num_conv_filters
+
         self.dropout = nn.Dropout(config.dropout)
         self.fc1 = nn.Linear(linear_size_temp, num_affine_neurons)
         self.fc2 = nn.Linear(num_affine_neurons, num_affine_neurons)

--- a/models/char_cnn/model.py
+++ b/models/char_cnn/model.py
@@ -19,6 +19,8 @@ class CharCNN(nn.Module):
         first_kernel_size = config.first_kernel
         second_kernel_size = config.second_kernel
         pool_size = config.pool_size
+        #whether we are using the fix version of the paper
+        self.using_fixed = config.using_fixed
 
         max_sentence_length = config.max_sentence_length  # maximum number of characters per sentence
 
@@ -27,15 +29,18 @@ class CharCNN(nn.Module):
         self.conv3 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
         self.conv4 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
         self.conv5 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
-        self.conv6 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
+        if self.using_fixed:
+            self.conv6 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
+            # due to reduction based on the convolutional  neural network
+            temp = first_kernel_size - 1 + pool_size * (first_kernel_size - 1) + (
+                    pool_size ** 2 * 4 * (second_kernel_size - 1))
+            linear_size_temp = int((max_sentence_length - temp) / (pool_size ** 3)) * num_conv_filters
 
-        # due to reduction based on the convolutional  neural network
-        temp = first_kernel_size - 1 + pool_size * (first_kernel_size - 1) + (
-                pool_size ** 2 * 4 * (second_kernel_size - 1))
-        linear_size_temp = int((max_sentence_length - temp) / (pool_size ** 3)) * num_conv_filters
-
+            self.fc1 = nn.Linear(linear_size_temp, num_affine_neurons)
+        else:
+            self.conv6 = nn.Conv1d(num_conv_filters, output_channel, kernel_size=second_kernel_size)
+            self.fc1 = nn.Linear(output_channel, num_affine_neurons)
         self.dropout = nn.Dropout(config.dropout)
-        self.fc1 = nn.Linear(linear_size_temp, num_affine_neurons)
         self.fc2 = nn.Linear(num_affine_neurons, num_affine_neurons)
         self.fc3 = nn.Linear(num_affine_neurons, target_class)
 
@@ -49,7 +54,11 @@ class CharCNN(nn.Module):
         x = F.relu(self.conv3(x))
         x = F.relu(self.conv4(x))
         x = F.relu(self.conv5(x))
-        x = F.max_pool1d(F.relu(self.conv6(x)), 3)
+        if self.using_fixed:
+            x = F.max_pool1d(F.relu(self.conv6(x)), 3)
+        else:
+            x = F.relu(self.conv6(x))
+            x = F.max_pool1d(x, x.size(2)).squeeze(2)
         x = F.relu(self.fc1(x.view(x.size(0), -1)))
         x = self.dropout(x)
         x = F.relu(self.fc2(x))

--- a/models/char_cnn/model.py
+++ b/models/char_cnn/model.py
@@ -14,12 +14,13 @@ class CharCNN(nn.Module):
         output_channel = config.output_channel
         num_affine_neurons = config.num_affine_neurons
         target_class = config.target_class
+        #added paremeters in the config
+        input_channel = config.number_of_characters #number of characters
+        first_kernel_size = config.first_kernel
+        second_kernel_size = config.second_kernel
+        pool_size = config.pool_size
         # we can add these parameters in the config
-        input_channel = 68 #number of characters
-        first_kernel_size = 7
-        second_kernel_size = 3
-        pool_size = 3
-        max_sentence_length = 1014 #maximum number of characters per sentence
+        max_sentence_length = config.max_sentence_length #maximum number of characters per sentence
 
         self.conv1 = nn.Conv1d(input_channel, num_conv_filters, kernel_size=first_kernel_size)
         self.conv2 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=first_kernel_size)
@@ -32,7 +33,6 @@ class CharCNN(nn.Module):
         temp = first_kernel_size - 1 + pool_size * (first_kernel_size - 1) + (
                 pool_size ** 2 * 4 * (second_kernel_size - 1))
         linear_size_temp = int((max_sentence_length - temp) / (pool_size ** 3)) * num_conv_filters
-
         self.dropout = nn.Dropout(config.dropout)
         self.fc1 = nn.Linear(linear_size_temp, num_affine_neurons)
         self.fc2 = nn.Linear(num_affine_neurons, num_affine_neurons)
@@ -43,14 +43,12 @@ class CharCNN(nn.Module):
             x = x.transpose(1, 2).type(torch.cuda.FloatTensor)
         else:
             x = x.transpose(1, 2).type(torch.FloatTensor)
-
         x = F.max_pool1d(F.relu(self.conv1(x)), 3)
         x = F.max_pool1d(F.relu(self.conv2(x)), 3)
         x = F.relu(self.conv3(x))
         x = F.relu(self.conv4(x))
         x = F.relu(self.conv5(x))
         x = F.max_pool1d(F.relu(self.conv6(x)), 3)
-
         x = F.relu(self.fc1(x.view(x.size(0), -1)))
         x = self.dropout(x)
         x = F.relu(self.fc2(x))

--- a/models/char_cnn/model.py
+++ b/models/char_cnn/model.py
@@ -14,17 +14,27 @@ class CharCNN(nn.Module):
         output_channel = config.output_channel
         num_affine_neurons = config.num_affine_neurons
         target_class = config.target_class
-        input_channel = 68
+        # we can add these parameters in the config
+        input_channel = 68 #number of characters
+        first_kernel_size = 7
+        second_kernel_size = 3
+        pool_size = 3
+        max_sentence_length = 1014 #maximum number of characters per sentence
 
-        self.conv1 = nn.Conv1d(input_channel, num_conv_filters, kernel_size=7)
-        self.conv2 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=7)
-        self.conv3 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=3)
-        self.conv4 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=3)
-        self.conv5 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=3)
-        self.conv6 = nn.Conv1d(num_conv_filters, output_channel, kernel_size=3)
+        self.conv1 = nn.Conv1d(input_channel, num_conv_filters, kernel_size=first_kernel_size)
+        self.conv2 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=first_kernel_size)
+        self.conv3 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
+        self.conv4 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
+        self.conv5 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
+        self.conv6 = nn.Conv1d(num_conv_filters, num_conv_filters, kernel_size=second_kernel_size)
+
+        # due to reduction based on the convolutional  neural network
+        temp = first_kernel_size - 1 + pool_size * (first_kernel_size - 1) + (
+                pool_size ** 2 * 4 * (second_kernel_size - 1))
+        linear_size_temp = int((max_sentence_length - temp) / (pool_size ** 3)) * num_conv_filters
 
         self.dropout = nn.Dropout(config.dropout)
-        self.fc1 = nn.Linear(output_channel, num_affine_neurons)
+        self.fc1 = nn.Linear(linear_size_temp, num_affine_neurons)
         self.fc2 = nn.Linear(num_affine_neurons, num_affine_neurons)
         self.fc3 = nn.Linear(num_affine_neurons, target_class)
 
@@ -39,9 +49,8 @@ class CharCNN(nn.Module):
         x = F.relu(self.conv3(x))
         x = F.relu(self.conv4(x))
         x = F.relu(self.conv5(x))
-        x = F.relu(self.conv6(x))
+        x = F.max_pool1d(F.relu(self.conv6(x)), 3)
 
-        x = F.max_pool1d(x, x.size(2)).squeeze(2)
         x = F.relu(self.fc1(x.view(x.size(0), -1)))
         x = self.dropout(x)
         x = F.relu(self.fc2(x))

--- a/models/fasttext/README.md
+++ b/models/fasttext/README.md
@@ -1,0 +1,27 @@
+## Bag of Tricks for Efficient Text Classification
+
+Implementation of [FastText (2016)](https://arxiv.org/pdf/1607.01759.pdf)
+
+## Quick Start
+
+To run the model on Reuters dataset, just run the following from the Castor working directory:
+
+```
+python -m models.fasttext --dataset Reuters --batch-size 128 --lr 0.001 --seed 3435
+```
+
+The best model weights will be saved in
+
+```
+models/fasttext/saves/Reuters/best_model.pt
+```
+
+To test the model, you can use the following command.
+
+```
+python -m models.char_cnn --dataset Reuters --batch_size 32 --trained-model modelsfasttext/saves/Reuters/best_model.pt --seed 3435
+```
+
+## Settings
+
+Adam is used for training.

--- a/models/fasttext/README.md
+++ b/models/fasttext/README.md
@@ -7,20 +7,9 @@ Implementation of [FastText (2016)](https://arxiv.org/pdf/1607.01759.pdf)
 To run the model on Reuters dataset, just run the following from the Castor working directory:
 
 ```
-python -m models.fasttext --dataset Reuters --batch-size 128 --lr 0.001 --seed 3435
+python -m models.fasttext --dataset Reuters --batch-size 128 --lr 0.01 --seed 3435 --epochs 30
 ```
 
-The best model weights will be saved in
-
-```
-models/fasttext/saves/Reuters/best_model.pt
-```
-
-To test the model, you can use the following command.
-
-```
-python -m models.fasttext --dataset Reuters --batch_size 32 --trained-model models/fasttext/saves/Reuters/best_model.pt --seed 3435
-```
 
 ## Settings
 

--- a/models/fasttext/README.md
+++ b/models/fasttext/README.md
@@ -19,7 +19,7 @@ models/fasttext/saves/Reuters/best_model.pt
 To test the model, you can use the following command.
 
 ```
-python -m models.char_cnn --dataset Reuters --batch_size 32 --trained-model modelsfasttext/saves/Reuters/best_model.pt --seed 3435
+python -m models.fasttext --dataset Reuters --batch_size 32 --trained-model models/fasttext/saves/Reuters/best_model.pt --seed 3435
 ```
 
 ## Settings

--- a/models/fasttext/args.py
+++ b/models/fasttext/args.py
@@ -15,7 +15,7 @@ def get_args():
 
     parser.add_argument('--word-vectors-dir', default=os.path.join(os.pardir, 'hedwig-data', 'embeddings', 'word2vec'))
     parser.add_argument('--word-vectors-file', default='GoogleNews-vectors-negative300.txt')
-    parser.add_argument('--save-path', type=str, default=os.path.join('model_checkpoints', 'kim_cnn'))
+    parser.add_argument('--save-path', type=str, default=os.path.join('model_checkpoints', 'fasttext'))
     parser.add_argument('--resume-snapshot', type=str)
     parser.add_argument('--trained-model', type=str)
 

--- a/models/fasttext/model.py
+++ b/models/fasttext/model.py
@@ -35,8 +35,6 @@ class FastText(nn.Module):
             x = self.static_embed(x)  # (batch, sent_len, embed_dim)
         elif self.mode == 'non-static':
             x = self.non_static_embed(x)  # (batch, sent_len, embed_dim)
-        x = F.avg_pool1d(x.transpose(1,2), x.shape[1]).squeeze(2) # (batch, embed_dim)
+        x = F.avg_pool1d(x.transpose(1, 2), x.shape[1]).squeeze(2)  # (batch, embed_dim)
         logit = self.fc1(x)  # (batch, target_size)
         return logit
-
-

--- a/models/fasttext/model.py
+++ b/models/fasttext/model.py
@@ -35,9 +35,7 @@ class FastText(nn.Module):
             x = self.static_embed(x)  # (batch, sent_len, embed_dim)
         elif self.mode == 'non-static':
             x = self.non_static_embed(x)  # (batch, sent_len, embed_dim)
-
-        x = F.avg_pool1d(x, x.shape[1]).squeeze(1) # (batch, embed_dim)
-
+        x = F.avg_pool1d(x.transpose(1,2), x.shape[1]).squeeze(2) # (batch, embed_dim)
         logit = self.fc1(x)  # (batch, target_size)
         return logit
 

--- a/models/fasttext/model.py
+++ b/models/fasttext/model.py
@@ -36,7 +36,7 @@ class FastText(nn.Module):
         elif self.mode == 'non-static':
             x = self.non_static_embed(x)  # (batch, sent_len, embed_dim)
 
-        x = F.avg_pool2d(x, (x.shape[1], 1)).squeeze(1)  # (batch, embed_dim)
+        x = F.avg_pool1d(x, x.shape[1]).squeeze(1) # (batch, embed_dim)
 
         logit = self.fc1(x)  # (batch, target_size)
         return logit


### PR DESCRIPTION
By examining the great models that you have created, I saw that the code in char_cnn (Character-level Convolutional Networks for TextClassification) is not exactly the same as the model that the authors described in their paper.

In particular, in this pull request I added:

a)For the char_cnn model:
1)I changed the last (sixth) convolutional networks and the first linear layer of the char_cnn to the format that the author used.
2) I wrote the equation (line 33,34) for calculating the input size of the first linear layer based on the maximum number of characters of a sentence (this number can be added to the config file but I did not want to change more files so I just I added it as a constant in the model.py)

b)For the FastText model:

I change the  F.avg_pool2d(x, (x.shape[1], 1)).squeeze(1)  to F.avg_pool1d(x, x.shape[1]).squeeze(1) which are equivalent but I believe that by using  F.avg_pool1d will make the code more understandable  as the code right now uses F.avg_pool2d to basically do avg_pool1d.